### PR TITLE
OAuth Authorization files

### DIFF
--- a/blank-template.php
+++ b/blank-template.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Template Name: Blank Template
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+?><!DOCTYPE html>
+<html >
+<head>
+    <meta charset="<?php bloginfo('charset'); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body {
+            margin: 0;
+            padding: 50px;
+            font-family: 'Catamaran', sans-serif;
+            font-size: medium;
+            background: #f5f7fa;
+            /* height: 100vh; */
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
+        .container {
+            padding: 30px;
+            width: 100%;
+            max-width: 600px;
+        }
+
+        .prerequisite-box {
+            background-color: #f9f9ff;
+            border-left: 5px solid #7252df;
+            padding: 20px;
+            margin: 30px auto;
+            font-family: Catamaran, sans-serif;
+            max-width: 700px;
+            border-radius: 8px;
+            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
+        }
+
+        .prerequisite-box h2 {
+            color: #333;
+            margin-bottom: 12px;
+        }
+
+        .prerequisite-box ol {
+            padding-left: 20px;
+        }
+
+        .prerequisite-box li {
+            margin-bottom: 10px;
+        }
+
+        .prerequisite-box code {
+            background: #eee;
+            padding: 2px 5px;
+            border-radius: 4px;
+            font-size: 0.95em;
+        }
+
+
+        h2 {
+            margin-top: 0;
+            margin-bottom: 20px;
+            color: #333;
+        }
+
+        .btn {
+            background-color: #7252df;
+            color: white;
+            padding: 12px 20px;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 16px;
+            transition: background 0.3s ease;
+            margin-top: 10px;
+        }
+
+        .btn:hover {
+            background-color: #5c3ddf;
+        }
+        .form-group {
+            margin-bottom: 20px;
+            text-align: left;
+        }
+
+        label {
+            display: block;
+            margin-bottom: 6px;
+            font-weight: 500;
+        }
+
+        input[type="text"] {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            font-size: 14px;
+        }
+
+        pre {
+        display: block;
+        padding: 9.5px;
+        margin: 0 0 10px;
+        font-size: 13px;
+        line-height: 1.42857143;
+        color: #333;
+        word-break: break-all;
+        word-wrap: break-word;
+        background-color: #f5f5f5;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        white-space: break-spaces;
+        max-width: 100%;
+        overflow: auto;
+        }
+
+        .copy-btn {
+        background: #7252df;
+        color: white;
+        border: none;
+        padding: 6px 10px;
+        font-size: 12px;
+        border-radius: 4px;
+        cursor: pointer;
+        }
+
+        .revoke_acces_btn{
+            background: #ff4d4d;
+            color: white;
+            border: none;
+            padding: 6px 10px;
+            font-size: 12px;
+            border-radius: 4px;
+            cursor: pointer;
+            margin-left: 30px;
+        }
+
+        .notice {
+            padding: 15px 20px;
+            margin: 0px 0px 30px 30px;
+            /* margin-left: 30px; */
+            max-width: 600px;
+            font-family: Catamaran, sans-serif;
+            font-size: 16px;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+            text-align: center;
+        }
+
+        .success-msg {
+            background-color: #e6f7e9;
+            color: #2e7d32;
+            border: 5px solid #4caf50;
+        }
+
+        .error-msg {
+            background-color: #fdecea;
+            color: #c62828;
+            border: 5px solid #f44336;
+        }
+
+    </style>
+</head>
+<body <?php body_class(); ?>>
+    <main class="oauth-page-wrapper">
+        <?php
+        while (have_posts()) : the_post();
+            the_content(); // This will display your HTML form
+        endwhile;
+        ?>
+    </main>
+</body>
+</html>

--- a/blank-template.php
+++ b/blank-template.php
@@ -148,7 +148,7 @@ if (!defined('ABSPATH')) {
     <main class="oauth-page-wrapper">
         <?php
         while (have_posts()) : the_post();
-            the_content(); // This will display your HTML form
+            the_content(); // This will display your HTML form.
         endwhile;
         ?>
     </main>

--- a/blank-template.php
+++ b/blank-template.php
@@ -8,30 +8,26 @@ if (!defined('ABSPATH')) {
 }
 
 ?><!DOCTYPE html>
-<html >
+<html>
 <head>
     <meta charset="<?php bloginfo('charset'); ?>">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
-        body {
-            margin: 0;
-            padding: 50px;
-            font-family: 'Catamaran', sans-serif;
-            font-size: medium;
-            background: #f5f7fa;
-            /* height: 100vh; */
+        .cppro-cc-main-block {
             display: flex;
             justify-content: center;
             align-items: center;
+            padding: 50px;
         }
 
-        .container {
+        .cppro-cc-container {
+            margin: 0;
             padding: 30px;
             width: 100%;
             max-width: 600px;
         }
 
-        .prerequisite-box {
+        .cppro-cc-main-block .cppro-cc-container .cppro-cc-prerequisite-box {
             background-color: #f9f9ff;
             border-left: 5px solid #7252df;
             padding: 20px;
@@ -42,20 +38,20 @@ if (!defined('ABSPATH')) {
             box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
         }
 
-        .prerequisite-box h2 {
+        .cppro-cc-main-block .cppro-cc-container .cppro-cc-prerequisite-box h2 {
             color: #333;
             margin-bottom: 12px;
         }
 
-        .prerequisite-box ol {
+        .cppro-cc-main-block .cppro-cc-container .cppro-cc-prerequisite-box ol {
             padding-left: 20px;
         }
 
-        .prerequisite-box li {
+        .cppro-cc-main-block .cppro-cc-container .cppro-cc-prerequisite-box li {
             margin-bottom: 10px;
         }
 
-        .prerequisite-box code {
+        .cppro-cc-main-block .cppro-cc-container .cppro-cc-prerequisite-box code {
             background: #eee;
             padding: 2px 5px;
             border-radius: 4px;
@@ -63,13 +59,13 @@ if (!defined('ABSPATH')) {
         }
 
 
-        h2 {
+        .cppro-cc-main-block .cppro-cc-container .cppro-cc-header {
             margin-top: 0;
             margin-bottom: 20px;
             color: #333;
         }
 
-        .btn {
+        .cppro-cc-main-block .cppro-cc-container .cppro-cc-connect-btn {
             background-color: #7252df;
             color: white;
             padding: 12px 20px;
@@ -81,21 +77,21 @@ if (!defined('ABSPATH')) {
             margin-top: 10px;
         }
 
-        .btn:hover {
+        .cppro-cc-main-block .cppro-cc-container .cppro-cc-connect-btn:hover {
             background-color: #5c3ddf;
         }
-        .form-group {
+        .cppro-cc-main-block .cppro-cc-container .form-group {
             margin-bottom: 20px;
             text-align: left;
         }
 
-        label {
+        .cppro-cc-container .form-group label {
             display: block;
             margin-bottom: 6px;
             font-weight: 500;
         }
 
-        input[type="text"] {
+        .cppro-cc-main-block .cppro-cc-container input[type="text"] {
             width: 100%;
             padding: 10px;
             border: 1px solid #ccc;
@@ -103,48 +99,35 @@ if (!defined('ABSPATH')) {
             font-size: 14px;
         }
 
-        pre {
-        display: block;
-        padding: 9.5px;
-        margin: 0 0 10px;
-        font-size: 13px;
-        line-height: 1.42857143;
-        color: #333;
-        word-break: break-all;
-        word-wrap: break-word;
-        background-color: #f5f5f5;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-        white-space: break-spaces;
-        max-width: 100%;
-        overflow: auto;
-        }
-
-        .copy-btn {
-        background: #7252df;
-        color: white;
-        border: none;
-        padding: 6px 10px;
-        font-size: 12px;
-        border-radius: 4px;
-        cursor: pointer;
-        }
-
-        .revoke_acces_btn{
-            background: #ff4d4d;
-            color: white;
-            border: none;
-            padding: 6px 10px;
-            font-size: 12px;
+        .ccpro-cc-token-box {
+            display: block;
+            padding: 9.5px;
+            margin: 0 0 10px;
+            font-size: 13px;
+            line-height: 1.42857143;
+            color: #333;
+            word-break: break-all;
+            word-wrap: break-word;
+            background-color: #f5f5f5;
+            border: 1px solid #ccc;
             border-radius: 4px;
-            cursor: pointer;
-            margin-left: 30px;
+            white-space: break-spaces;
+            max-width: 100%;
+            overflow: auto;
         }
 
-        .notice {
+        .cppro-cc-revoke_acces_btn{
+            background-color: #7252df;
+            color: #fff;
+            padding: 12px 20px;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+
+        .cppro-cc-notice {
             padding: 15px 20px;
-            margin: 0px 0px 30px 30px;
-            /* margin-left: 30px; */
             max-width: 600px;
             font-family: Catamaran, sans-serif;
             font-size: 16px;
@@ -153,13 +136,7 @@ if (!defined('ABSPATH')) {
             text-align: center;
         }
 
-        .success-msg {
-            background-color: #e6f7e9;
-            color: #2e7d32;
-            border: 5px solid #4caf50;
-        }
-
-        .error-msg {
+        .cppro-cc-error-msg {
             background-color: #fdecea;
             color: #c62828;
             border: 5px solid #f44336;
@@ -167,7 +144,7 @@ if (!defined('ABSPATH')) {
 
     </style>
 </head>
-<body <?php body_class(); ?>>
+<body>
     <main class="oauth-page-wrapper">
         <?php
         while (have_posts()) : the_post();

--- a/constant-contact-oauth2.php
+++ b/constant-contact-oauth2.php
@@ -14,9 +14,19 @@ if (!session_id()) {
     session_start();
 }
 
+// Register Shortcode.
 add_shortcode('oauth_connect', 'Constant_Contact_Oauth_Connect');
+
+// Remove header and footer for the OAuth page.
 add_action('template_redirect', 'Load_Blank_Template_For_Oauth_page');
 
+/**
+ * Loads a blank template for the OAuth page.
+ *
+ * This function checks if the current page is the OAuth page and, if so,
+ * applies a filter to load a blank template, removing the header and footer.
+ *
+ */
 function Load_Blank_Template_For_Oauth_page() {
     if (is_page('oauth-connect2')) {
         add_filter('template_include', function($template) {
@@ -25,30 +35,38 @@ function Load_Blank_Template_For_Oauth_page() {
     }
 }
 
+/**
+ * Handles the OAuth connection process for Constant Contact.
+ *
+ * This function renders a form for entering Constant Contact credentials,
+ * processes the form submission, and handles the OAuth flow, including
+ * generating access tokens and displaying them.
+ * 
+ */
 function Constant_Contact_Oauth_Connect() {
-    ob_start();
-
-    $client_id = get_option('cc_client_id');
-    $client_secret = get_option('cc_client_secret');
-    $access_token = get_option('cc_access_token');
-    $refresh_token = get_option('cc_refresh_token');
-    $code = isset($_GET['code']) ? sanitize_text_field($_GET['code']) : null;
-
+    // Handle redirect BEFORE output
     if (isset($_POST['connect'])) {
-        $client_id = sanitize_text_field($_POST['client_id']);
-        $client_secret = sanitize_text_field($_POST['client_secret']);
-        update_option('cc_client_id', $client_id);
-        update_option('cc_client_secret', $client_secret);
-        $state = bin2hex(random_bytes(16));
-        $_SESSION['oauth_state'] = $state;
+        $_SESSION['cc_client_id'] = sanitize_text_field($_POST['client_id']);
+        $_SESSION['cc_client_secret'] = sanitize_text_field($_POST['client_secret']);
+        $_SESSION['oauth_state'] = bin2hex(random_bytes(16));
 
         $redirect_uri = home_url('/oauth-connect2/');
         $scope = rawurlencode("contact_data campaign_data offline_access");
-        $auth_url = "https://authz.constantcontact.com/oauth2/default/v1/authorize?client_id={$client_id}&redirect_uri={$redirect_uri}&response_type=code&scope={$scope}&state={$state}";
 
+        $auth_url = "https://authz.constantcontact.com/oauth2/default/v1/authorize?client_id={$_SESSION['cc_client_id']}&redirect_uri={$redirect_uri}&response_type=code&scope={$scope}&state={$_SESSION['oauth_state']}";
+
+        if (ob_get_length()) ob_end_clean();
         wp_redirect($auth_url);
         exit;
     }
+
+    ob_start();
+
+    $client_id     = $_SESSION['cc_client_id'] ?? null;
+    $client_secret = $_SESSION['cc_client_secret'] ?? null;
+    $access_token  = $_SESSION['cc_access_token'] ?? null;
+    $refresh_token = $_SESSION['cc_refresh_token'] ?? null;
+    $code = isset($_GET['code']) ? sanitize_text_field($_GET['code']) : null;
 
     $show_token_section = false;
     $error_message = '';
@@ -56,9 +74,9 @@ function Constant_Contact_Oauth_Connect() {
     if ($code && empty($_SESSION['token_displayed'])) {
         $access_token_data = getAccessToken($code, $client_id, $client_secret, home_url('/oauth-connect2/'));
         if ($access_token_data && isset($access_token_data['access_token'])) {
-            update_option('cc_access_token', $access_token_data['access_token']);
-            update_option('cc_refresh_token', $access_token_data['refresh_token']);
-            update_option('cc_token_expiry', time() + $access_token_data['expires_in']);
+            $_SESSION['cc_access_token'] = $access_token_data['access_token'];
+            $_SESSION['cc_refresh_token'] = $access_token_data['refresh_token'];
+            $_SESSION['cc_token_expiry'] = time() + $access_token_data['expires_in'];
             $_SESSION['token_displayed'] = true;
             $show_token_section = true;
         } else {
@@ -69,15 +87,8 @@ function Constant_Contact_Oauth_Connect() {
         $_SESSION['token_displayed'] = null;
     }
 
-    if (isset($_POST['revoke_access'])) {
-        revokeAuthorization();
-        $access_token = $refresh_token = null;
-        $_SESSION['token_displayed'] = null;
-    }
-
     if (isset($_POST['go_back'])) {
         $_SESSION['token_displayed'] = null;
-        $show_token_section = false;
     }
 
     echo '<div class="cppro-cc-main-block"><div class="cppro-cc-container">';
@@ -86,13 +97,12 @@ function Constant_Contact_Oauth_Connect() {
         echo '<div class="cppro-cc-notice cppro-cc-error-msg">' . esc_html($error_message) . '</div>';
     }
 
-    if ($show_token_section) {
+    if (!empty($_SESSION['token_displayed'])) {
         echo '<form method="POST"><button class="cppro-cc-revoke_acces_btn" type="submit" name="go_back">Enter Client Credentials</button></form>';
         echo '<div class="token-output">';
         echo '<h3>Access Token</h3><pre class="ccpro-cc-token-box">' . esc_html($access_token ?: 'Not Found') . '</pre>';
         echo '<h3>Refresh Token</h3><pre class="ccpro-cc-token-box">' . esc_html($refresh_token ?: 'Not Found') . '</pre>';
         echo '</div>';
-        // echo '<form method="POST"><button class="cppro-cc-revoke_acces_btn" type="submit" name="revoke_access">Revoke Access</button></form>';
     } else {
         echo '<div class="cppro-cc-prerequisite-box">';
         echo '<h2 class="cppro-cc-header">🔧 Before You Start</h2>';
@@ -114,11 +124,21 @@ function Constant_Contact_Oauth_Connect() {
         echo '<button type="submit" name="connect" class="cppro-cc-connect-btn">Connect to Constant Contact</button>';
         echo '</form>';
     }
+
     echo '</div></div>';
 
     return ob_get_clean();
 }
 
+/**
+ * Function to Exchange Authorization Code for Access Token.
+ *
+ * @param string $code The authorization code received from the OAuth server.
+ * @param string $client_id The client ID of the Constant Contact application.
+ * @param string $client_secret The client secret of the Constant Contact application.
+ * @param string $redirect_uri The redirect URI registered with the Constant Contact application.
+ * @return array|null The access token data or null if the request fails.
+ */
 function getAccessToken($code, $client_id, $client_secret, $redirect_uri) {
     $url = "https://authz.constantcontact.com/oauth2/default/v1/token";
     $data = ["code" => $code, "redirect_uri" => $redirect_uri, "grant_type" => "authorization_code"];
@@ -138,42 +158,4 @@ function getAccessToken($code, $client_id, $client_secret, $redirect_uri) {
     curl_close($ch);
 
     return json_decode($response, true);
-}
-
-function refreshAccessToken($client_id, $client_secret) {
-    $refresh_token = get_option('cc_refresh_token');
-    if (!$refresh_token) return "Error: No refresh token available.";
-
-    $url = "https://authz.constantcontact.com/oauth2/default/v1/token";
-    $data = ["refresh_token" => $refresh_token, "grant_type" => "refresh_token"];
-    $auth = base64_encode("$client_id:$client_secret");
-
-    $ch = curl_init($url);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_POST, true);
-    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
-    curl_setopt($ch, CURLOPT_HTTPHEADER, [
-        "Authorization: Basic $auth",
-        "Content-Type: application/x-www-form-urlencoded",
-        "Accept: application/json"
-    ]);
-
-    $response = curl_exec($ch);
-    curl_close($ch);
-
-    $tokens = json_decode($response, true);
-    if (isset($tokens['access_token'])) {
-        update_option('cc_access_token', $tokens['access_token']);
-        update_option('cc_refresh_token', $tokens['refresh_token']);
-        update_option('cc_token_expiry', time() + $tokens['expires_in']);
-        return $tokens['access_token'];
-    }
-
-    return "Error: Failed to refresh token.";
-}
-
-function revokeAuthorization() {
-    delete_option('cc_access_token');
-    delete_option('cc_refresh_token');
-    delete_option('cc_token_expiry');
 }

--- a/constant-contact-oauth2.php
+++ b/constant-contact-oauth2.php
@@ -4,17 +4,23 @@
  * Description: Adds a shortcode to handle OAuth connection with Constant Contact.
  * Version: 1.0
  * Author: Brainstorm Force
+ * 
+ * This plugin facilitates OAuth 2.0 authentication with Constant Contact API.
+ * It provides a shortcode [oauth_connect] to render a form for connecting to 
+ * Constant Contact, authorizing the application, and retrieving access tokens.
  */
 
+ // Exit if accessed directly.
 if (!defined('ABSPATH')) {
     exit;
 }
 
+// Start PHP session if not already started.
 if (!session_id()) {
     session_start();
 }
 
-// Register Shortcode.
+// Register Shortcode for OAuth connection form.
 add_shortcode('oauth_connect', 'Constant_Contact_Oauth_Connect');
 
 // Remove header and footer for the OAuth page.
@@ -44,7 +50,8 @@ function Load_Blank_Template_For_Oauth_page() {
  * 
  */
 function Constant_Contact_Oauth_Connect() {
-    // Handle redirect BEFORE output
+
+    // Handle the initial form submission to start the OAuth flow.
     if (isset($_POST['connect'])) {
         $_SESSION['cc_client_id'] = sanitize_text_field($_POST['client_id']);
         $_SESSION['cc_client_secret'] = base64_encode(sanitize_text_field($_POST['client_secret']));
@@ -53,6 +60,7 @@ function Constant_Contact_Oauth_Connect() {
         $redirect_uri = home_url('/oauth-connect2/');
         $scope = rawurlencode("contact_data campaign_data offline_access");
 
+        // Authorization URL.
         $auth_url = "https://authz.constantcontact.com/oauth2/default/v1/authorize?client_id={$_SESSION['cc_client_id']}&redirect_uri={$redirect_uri}&response_type=code&scope={$scope}&state={$_SESSION['oauth_state']}";
 
         if (ob_get_length()) ob_end_clean();
@@ -70,61 +78,79 @@ function Constant_Contact_Oauth_Connect() {
 
     $error_message = '';
 
+    // Check if the authorization code is present in the URL.
     if ($code && empty($_SESSION['token_displayed'])) {
+        // Exchange authorization code for access token.
         $access_token_data = getAccessToken($code, $client_id, $client_secret, home_url('/oauth-connect2/'));
         if ($access_token_data && isset($access_token_data['access_token'])) {
             $_SESSION['cc_access_token'] = $access_token_data['access_token'];
             $_SESSION['cc_refresh_token'] = $access_token_data['refresh_token'];
-            $_SESSION['cc_token_expiry'] = time() + $access_token_data['expires_in'];
             $_SESSION['token_displayed'] = true;
         } else {
+            // Handle error if token exchange fails.
             $error_message = 'The authorization code is invalid or has expired. Please enter valid credentials.';
         }
     } elseif ($code && !empty($_SESSION['token_displayed'])) {
+        // If the token has already been displayed, do not process it again.
         $error_message = 'The authorization code is invalid or has expired. Please enter valid credentials.';
         $_SESSION['token_displayed'] = null;
     }
 
+    // Handle token revocation request.
+    if (isset($_POST['revoke_access'])) {
+        revokeAuthorization();
+        $access_token = $refresh_token = null;
+        $_SESSION['token_displayed'] = null;
+    }
+
+    // Handle return to credentials form.
     if (isset($_POST['go_back'])) {
         $_SESSION['token_displayed'] = null;
     }
 
+    // Output the HTML for the OAuth connection form.
     echo '<div class="cppro-cc-main-block"><div class="cppro-cc-container">';
 
     if (!empty($error_message)) {
         echo '<div class="cppro-cc-notice cppro-cc-error-msg">' . esc_html($error_message) . '</div>';
     }
 
+    // Display token information if available.
     if (!empty($_SESSION['token_displayed'])) {
-        echo '<form method="POST"><button class="cppro-cc-revoke_acces_btn" type="submit" name="go_back">Enter Client Credentials</button></form>';
-        echo '<div class="token-output">';
-        echo '<h3>Access Token</h3><pre class="ccpro-cc-token-box">' . esc_html($access_token ?: 'Not Found') . '</pre>';
-        echo '<h3>Refresh Token</h3><pre class="ccpro-cc-token-box">' . esc_html($refresh_token ?: 'Not Found') . '</pre>';
-        echo '</div>';
+        $output = '<form method="POST"><button class="cppro-cc-revoke_acces_btn" type="submit" name="go_back">Enter Client Credentials</button></form>';
+        $output .= '<div class="token-output">';
+        $output .= '<h3>Access Token</h3><pre class="ccpro-cc-token-box">' . esc_html($access_token ?: 'Not Found') . '</pre>';
+        $output .= '<h3>Refresh Token</h3><pre class="ccpro-cc-token-box">' . esc_html($refresh_token ?: 'Not Found') . '</pre>';
+        $output .= '<form method="POST"><button class="cppro-cc-revoke_acces_btn" type="submit" name="revoke_access">Revoke Access</button></form>';
+        $output .= '</div>';
+        
+        echo $output;
     } else {
-        echo '<div class="cppro-cc-prerequisite-box">';
-        echo '<h2 class="cppro-cc-header">🔧 Before You Start</h2>';
-        echo '<p>Follow these steps before connecting to Constant Contact:</p>';
-        echo '<ol>';
-        echo '<li>Go to the <a href="https://developer.constantcontact.com/" target="_blank">Constant Contact App Portal</a>.</li>';
-        echo '<li>Create a new application and copy the Client ID and Secret.</li>';
-        echo '<li>Set the Redirect URI to: <code>' . home_url('/oauth-connect2/') . '</code></li>';
-        echo '</ol>';
-        echo '<p>Enter your credentials below.</p>';
-        echo '</div>';
-
-        echo '<h2 class="cc-header">Connect to Constant Contact</h2>';
-        echo '<form method="POST">';
-        echo '<div class="form-group"><label for="client_id">Client ID</label>';
-        echo '<input type="text" name="client_id" id="client_id" required></div>';
-        echo '<div class="form-group"><label for="client_secret">Client Secret</label>';
-        echo '<input type="text" name="client_secret" id="client_secret" required></div>';
-        echo '<button type="submit" name="connect" class="cppro-cc-connect-btn">Connect to Constant Contact</button>';
-        echo '</form>';
+        // Display the credentials form and instructions.
+        $output = '<div class="cppro-cc-prerequisite-box">';
+        $output .= '<h2 class="cppro-cc-header">🔧 Before You Start</h2>';
+        $output .= '<p>Follow these steps before connecting to Constant Contact:</p>';
+        $output .= '<ol>';
+        $output .= '<li>Go to the <a href="https://developer.constantcontact.com/" target="_blank">Constant Contact App Portal</a>.</li>';
+        $output .= '<li>Create a new application and copy the Client ID and Secret.</li>';
+        $output .= '<li>Set the Redirect URI to: <code>' . home_url('/oauth-connect2/') . '</code></li>';
+        $output .= '</ol>';
+        $output .= '<p>Enter your credentials below.</p>';
+        $output .= '</div>';
+        
+        $output .= '<h2 class="cc-header">Connect to Constant Contact</h2>';
+        $output .= '<form method="POST">';
+        $output .= '<div class="form-group"><label for="client_id">Client ID</label>';
+        $output .= '<input type="text" name="client_id" id="client_id" required></div>';
+        $output .= '<div class="form-group"><label for="client_secret">Client Secret</label>';
+        $output .= '<input type="text" name="client_secret" id="client_secret" required></div>';
+        $output .= '<button type="submit" name="connect" class="cppro-cc-connect-btn">Connect to Constant Contact</button>';
+        $output .= '</form>';
+        
+        echo $output;
     }
 
     echo '</div></div>';
-
     return ob_get_clean();
 }
 
@@ -138,6 +164,7 @@ function Constant_Contact_Oauth_Connect() {
  * @return array|null The access token data or null if the request fails.
  */
 function getAccessToken($code, $client_id, $client_secret, $redirect_uri) {
+    // Prepare the token endpoint URL and request data.
     $url = "https://authz.constantcontact.com/oauth2/default/v1/token";
     $data = ["code" => $code, "redirect_uri" => $redirect_uri, "grant_type" => "authorization_code"];
     $auth = base64_encode("$client_id:$client_secret");
@@ -156,4 +183,23 @@ function getAccessToken($code, $client_id, $client_secret, $redirect_uri) {
     curl_close($ch);
 
     return json_decode($response, true);
+}
+
+/**
+ * Revokes authorization by clearing all session data related to Constant Contact.
+ *
+ * This function removes all OAuth-related data from the session,
+ * effectively revoking access to the Constant Contact API.
+ */
+function revokeAuthorization() {
+    unset($_SESSION['cc_access_token']);
+    unset($_SESSION['cc_refresh_token']);
+    unset($_SESSION['cc_client_id']);
+    unset($_SESSION['cc_client_secret']);
+    unset($_SESSION['token_displayed']);
+}
+
+// Handle Form Submission for Revoking Access
+if (isset($_POST['revoke_access'])) {
+    revokeAuthorization();
 }

--- a/constant-contact-oauth2.php
+++ b/constant-contact-oauth2.php
@@ -96,13 +96,6 @@ function Constant_Contact_Oauth_Connect() {
         $_SESSION['token_displayed'] = null;
     }
 
-    // Handle token revocation request.
-    if (isset($_POST['revoke_access'])) {
-        revokeAuthorization();
-        $access_token = $refresh_token = null;
-        $_SESSION['token_displayed'] = null;
-    }
-
     // Handle return to credentials form.
     if (isset($_POST['go_back'])) {
         $_SESSION['token_displayed'] = null;
@@ -117,11 +110,13 @@ function Constant_Contact_Oauth_Connect() {
 
     // Display token information if available.
     if (!empty($_SESSION['token_displayed'])) {
+        // Display the access and refresh tokens.
+        $access_token = $_SESSION['cc_access_token'] ?? null;
+        $refresh_token = $_SESSION['cc_refresh_token'] ?? null;
         $output = '<form method="POST"><button class="cppro-cc-revoke_acces_btn" type="submit" name="go_back">Enter Client Credentials</button></form>';
         $output .= '<div class="token-output">';
         $output .= '<h3>Access Token</h3><pre class="ccpro-cc-token-box">' . esc_html($access_token ?: 'Not Found') . '</pre>';
         $output .= '<h3>Refresh Token</h3><pre class="ccpro-cc-token-box">' . esc_html($refresh_token ?: 'Not Found') . '</pre>';
-        $output .= '<form method="POST"><button class="cppro-cc-revoke_acces_btn" type="submit" name="revoke_access">Revoke Access</button></form>';
         $output .= '</div>';
         
         echo $output;
@@ -133,7 +128,7 @@ function Constant_Contact_Oauth_Connect() {
         $output .= '<ol>';
         $output .= '<li>Go to the <a href="https://developer.constantcontact.com/" target="_blank">Constant Contact App Portal</a>.</li>';
         $output .= '<li>Create a new application and copy the Client ID and Secret.</li>';
-        $output .= '<li>Set the Redirect URI to: <code>' . home_url('/oauth-connect2/') . '</code></li>';
+        $output .= '<li>Set the Redirect URI to: <code>' . esc_url(home_url('/oauth-connect2/')) . '</code></li>';
         $output .= '</ol>';
         $output .= '<p>Enter your credentials below.</p>';
         $output .= '</div>';
@@ -151,7 +146,19 @@ function Constant_Contact_Oauth_Connect() {
     }
 
     echo '</div></div>';
-    return ob_get_clean();
+
+    $content = ob_get_clean(); // store output.
+    if (!empty($_SESSION['token_displayed'])) {
+        // Clear session variables after displaying the tokens.
+        unset($_SESSION['cc_access_token']);
+        unset($_SESSION['cc_refresh_token']);
+        unset($_SESSION['cc_client_id']);
+        unset($_SESSION['cc_client_secret']);
+        unset($_SESSION['cc_token_expiry']);
+        unset($_SESSION['token_displayed']);
+    }
+    
+    return $content; // finally return cleaned output.
 }
 
 /**
@@ -183,23 +190,4 @@ function getAccessToken($code, $client_id, $client_secret, $redirect_uri) {
     curl_close($ch);
 
     return json_decode($response, true);
-}
-
-/**
- * Revokes authorization by clearing all session data related to Constant Contact.
- *
- * This function removes all OAuth-related data from the session,
- * effectively revoking access to the Constant Contact API.
- */
-function revokeAuthorization() {
-    unset($_SESSION['cc_access_token']);
-    unset($_SESSION['cc_refresh_token']);
-    unset($_SESSION['cc_client_id']);
-    unset($_SESSION['cc_client_secret']);
-    unset($_SESSION['token_displayed']);
-}
-
-// Handle Form Submission for Revoking Access
-if (isset($_POST['revoke_access'])) {
-    revokeAuthorization();
 }

--- a/constant-contact-oauth2.php
+++ b/constant-contact-oauth2.php
@@ -47,7 +47,7 @@ function Constant_Contact_Oauth_Connect() {
     // Handle redirect BEFORE output
     if (isset($_POST['connect'])) {
         $_SESSION['cc_client_id'] = sanitize_text_field($_POST['client_id']);
-        $_SESSION['cc_client_secret'] = sanitize_text_field($_POST['client_secret']);
+        $_SESSION['cc_client_secret'] = base64_encode(sanitize_text_field($_POST['client_secret']));
         $_SESSION['oauth_state'] = bin2hex(random_bytes(16));
 
         $redirect_uri = home_url('/oauth-connect2/');
@@ -63,12 +63,11 @@ function Constant_Contact_Oauth_Connect() {
     ob_start();
 
     $client_id     = $_SESSION['cc_client_id'] ?? null;
-    $client_secret = $_SESSION['cc_client_secret'] ?? null;
+    $client_secret = isset($_SESSION['cc_client_secret']) ? base64_decode($_SESSION['cc_client_secret']) : null;
     $access_token  = $_SESSION['cc_access_token'] ?? null;
     $refresh_token = $_SESSION['cc_refresh_token'] ?? null;
     $code = isset($_GET['code']) ? sanitize_text_field($_GET['code']) : null;
 
-    $show_token_section = false;
     $error_message = '';
 
     if ($code && empty($_SESSION['token_displayed'])) {
@@ -78,7 +77,6 @@ function Constant_Contact_Oauth_Connect() {
             $_SESSION['cc_refresh_token'] = $access_token_data['refresh_token'];
             $_SESSION['cc_token_expiry'] = time() + $access_token_data['expires_in'];
             $_SESSION['token_displayed'] = true;
-            $show_token_section = true;
         } else {
             $error_message = 'The authorization code is invalid or has expired. Please enter valid credentials.';
         }

--- a/constant-contact-oauth2.php
+++ b/constant-contact-oauth2.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * Plugin Name: Constant Contact OAuth Connect
+ * Description: Adds a shortcode to handle OAuth connection with Constant Contact.
+ * Version: 1.0
+ * Author: Brainstorm Force
+ */
+
+if (!defined('ABSPATH')) {
+    exit; // Prevent direct access
+}
+
+// Start the session if not already started
+if (!session_id()) {
+    session_start();
+}
+
+// Register Shortcode
+add_shortcode('oauth_connect', 'Constant_Contact_Oauth_Connect');
+
+// Remove header and footer for the OAuth page
+add_action('template_redirect', 'Load_Blank_Template_For_Oauth_page');
+
+/**
+ * Loads a blank template for the OAuth page.
+ *
+ * This function checks if the current page is the OAuth page and, if so,
+ * applies a filter to load a blank template, removing the header and footer.
+ *
+ */
+function Load_Blank_Template_For_Oauth_page() {
+    // Check if the current page is the OAuth page
+    if (is_page('oauth-connect2')) { // Replace 'oauth-connect2' with your page slug
+        add_filter('template_include', function($template) {
+            // Load a blank template
+            return plugin_dir_path(__FILE__) . 'blank-template.php';
+        });
+    }
+}
+
+/**
+ * Handles the OAuth connection process for Constant Contact.
+ *
+ * This function renders a form for entering Constant Contact credentials,
+ * processes the form submission, and handles the OAuth flow, including
+ * generating access tokens and displaying them.
+ * 
+ */
+function Constant_Contact_Oauth_Connect() {
+    ob_start();
+    
+    // Retrieve stored credentials
+    $client_id = get_option('cc_client_id');
+    $client_secret = get_option('cc_client_secret');
+    ?>
+
+    <div class="container">
+
+        <div class="prerequisite-box">
+            <h2>🔧 Before You Start</h2>
+            <p>Follow these steps before connecting to Constant Contact:</p>
+            <ol>
+                <li>Go to the <a href="https://developer.constantcontact.com/" target="_blank" rel="noopener noreferrer">Constant Contact App Portal</a>.</li>
+                <li>Create a new application with a name of your choice.</li>
+                <li>Copy the <strong>API Key (Client ID)</strong> from the app details page.</li>
+                <li>Click <strong>Generate Client Secret</strong> and copy the code.</li>
+                <li>Set the <strong>Redirect URI</strong> to:<br><code>https://www.convertpro.net/oauth-connect2/</code></li>
+            </ol>
+            <p>Once you've completed these steps, enter your credentials below.</p>
+        </div>
+
+
+        <h2 class="cc-header" >Connect to Constant Contact</h2>
+
+        <form method="POST">
+            <div class="form-group">
+                <label for="client_id">Client ID</label>
+                <input type="text" name="client_id" id="client_id" required value="">
+            </div>
+            <div class="form-group">
+                <label for="client_secret">Client Secret</label>
+                <input type="text" name="client_secret" id="client_secret" required value="">
+            </div>
+
+            <button type="submit" name="connect" class="btn">Connect to Constant Contact</button>
+        </form>
+    </div>
+
+    <?php
+
+    if (isset($_POST['connect'])) {
+        $client_id = sanitize_text_field($_POST['client_id']);
+        $client_secret = sanitize_text_field($_POST['client_secret']);
+        update_option('cc_client_id', $client_id);
+        update_option('cc_client_secret', $client_secret);
+
+        //Generate state token and save in session
+        $state = bin2hex(random_bytes(16));
+
+        // Redirect to OAuth authorization URL
+        $redirect_uri = home_url('/oauth-connect2/');
+        $scope = rawurlencode("contact_data campaign_data offline_access");
+
+        $auth_url = "https://authz.constantcontact.com/oauth2/default/v1/authorize?client_id={$client_id}&redirect_uri={$redirect_uri}&response_type=code&scope={$scope}&state={$state}";
+        
+        wp_redirect($auth_url);
+        exit;
+    }
+
+
+    if (isset($_GET['code'])) {
+        $client_id = get_option('cc_client_id');
+        $client_secret = get_option('cc_client_secret');
+        $code = sanitize_text_field($_GET['code']);
+        $redirect_uri = home_url('/oauth-connect2/');
+
+        $access_token_data = getAccessToken($code, $client_id, $client_secret, $redirect_uri);
+
+        if ($access_token_data && isset($access_token_data['access_token'])) {
+            update_option('cc_access_token', $access_token_data['access_token']);
+            update_option('cc_refresh_token', $access_token_data['refresh_token']);
+            update_option('cc_token_expiry', time() + $access_token_data['expires_in']);
+            ?>
+                <div class="notice success-msg">
+                    Successfully Connected!
+                </div>
+            <?php
+        } else {
+            ?>
+                <div class="notice error-msg">
+                    The authorization code is invalid or has expired. Please enter valid credentials.
+                </div>
+            <?php
+        }
+    }
+
+    ?>
+
+    <!-- Revoke Access button -->
+    <form method="POST">
+        <button class="revoke_acces_btn" type="submit" name="revoke_access">Revoke Access</button>
+    </form>
+    <?php
+    $access_token = get_option('cc_access_token');
+    $refresh_token = get_option('cc_refresh_token');
+    // $token_expiry = get_option('cc_token_expiry');
+    
+    ?> 
+    
+    <!-- Access Token Display -->
+    <div class="container">
+        <div class="token-output">
+            <h3>Access Token</h3>
+            <pre class="token-box" id="access_token_box">
+                <?php 
+                    echo $access_token ?: "Not Found";
+                ?>
+            </pre>
+            <!-- <button id="copy-access" class="copy-btn" onclick="copyToken('access_token_box')">Copy</button> -->
+
+            <h3>Refresh Token</h3>
+            <pre class="token-box" id="refresh_token_box">
+                <?php 
+                    echo $refresh_token ?: "Not Found";
+                ?>
+            </pre>
+            <!-- <button id="copy-refresh" class="copy-btn" onclick="copyToken('refresh_token_box')">Copy</button> -->
+        </div>
+    </div>
+
+    <?php
+    return ob_get_clean();
+}
+
+/**
+ * Function to Exchange Authorization Code for Access Token.
+ *
+ * @param string $code The authorization code received from the OAuth server.
+ * @param string $client_id The client ID of the Constant Contact application.
+ * @param string $client_secret The client secret of the Constant Contact application.
+ * @param string $redirect_uri The redirect URI registered with the Constant Contact application.
+ * @return array|null The access token data or null if the request fails.
+ */
+function getAccessToken($code, $client_id, $client_secret, $redirect_uri) {
+    $url = "https://authz.constantcontact.com/oauth2/default/v1/token";
+    $data = [
+        "code" => $code,
+        "redirect_uri" => $redirect_uri,
+        "grant_type" => "authorization_code"
+    ];
+    
+    $auth = base64_encode("$client_id:$client_secret");
+
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        "Authorization: Basic $auth",
+        "Content-Type: application/x-www-form-urlencoded",
+        "Accept: application/json"
+    ]);
+
+    $response = curl_exec($ch);
+    curl_close($ch);
+
+    return json_decode($response, true);
+}
+
+/**
+ * Function to Refresh Access Token.
+ *
+ * @param string $client_id The client ID of the Constant Contact application.
+ * @param string $client_secret The client secret of the Constant Contact application.
+ * @return string The new access token or an error message if the refresh fails.
+ */
+function refreshAccessToken($client_id, $client_secret) {
+    $refresh_token = get_option('cc_refresh_token');
+
+    if (!$refresh_token) {
+        return "Error: No refresh token available.";
+    }
+
+    $url = "https://authz.constantcontact.com/oauth2/default/v1/token";
+    $data = [
+        "refresh_token" => $refresh_token,
+        "grant_type" => "refresh_token"
+    ];
+
+    $auth = base64_encode("$client_id:$client_secret");
+
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        "Authorization: Basic $auth",
+        "Content-Type: application/x-www-form-urlencoded",
+        "Accept: application/json"
+    ]);
+
+    $response = curl_exec($ch);
+    curl_close($ch);
+
+    $tokens = json_decode($response, true);
+
+    if (isset($tokens['access_token'])) {
+        update_option('cc_access_token', $tokens['access_token']);
+        update_option('cc_refresh_token', $tokens['refresh_token']);
+        update_option('cc_token_expiry', time() + $tokens['expires_in']);
+        return $tokens['access_token'];
+    } else {
+        return "Error: Failed to refresh token.";
+    }
+}
+
+/**
+ * Function to Revoke Authorization.
+ *
+ * This function deletes the stored access token, refresh token, 
+ * and token expiry time from the WordPress options, effectively 
+ * disconnecting the user from Constant Contact.
+ */
+function revokeAuthorization() {
+    delete_option('cc_access_token');
+    delete_option('cc_refresh_token');
+    delete_option('cc_token_expiry');
+}
+
+// Handle Form Submission for Revoking Access
+if (isset($_POST['revoke_access'])) {
+    revokeAuthorization();
+}
+
+?>

--- a/constant-contact-oauth2.php
+++ b/constant-contact-oauth2.php
@@ -7,188 +7,121 @@
  */
 
 if (!defined('ABSPATH')) {
-    exit; // Prevent direct access
+    exit;
 }
 
-// Start the session if not already started
 if (!session_id()) {
     session_start();
 }
 
-// Register Shortcode
 add_shortcode('oauth_connect', 'Constant_Contact_Oauth_Connect');
-
-// Remove header and footer for the OAuth page
 add_action('template_redirect', 'Load_Blank_Template_For_Oauth_page');
 
-/**
- * Loads a blank template for the OAuth page.
- *
- * This function checks if the current page is the OAuth page and, if so,
- * applies a filter to load a blank template, removing the header and footer.
- *
- */
 function Load_Blank_Template_For_Oauth_page() {
-    // Check if the current page is the OAuth page
-    if (is_page('oauth-connect2')) { // Replace 'oauth-connect2' with your page slug
+    if (is_page('oauth-connect2')) {
         add_filter('template_include', function($template) {
-            // Load a blank template
             return plugin_dir_path(__FILE__) . 'blank-template.php';
         });
     }
 }
 
-/**
- * Handles the OAuth connection process for Constant Contact.
- *
- * This function renders a form for entering Constant Contact credentials,
- * processes the form submission, and handles the OAuth flow, including
- * generating access tokens and displaying them.
- * 
- */
 function Constant_Contact_Oauth_Connect() {
     ob_start();
-    
-    // Retrieve stored credentials
+
     $client_id = get_option('cc_client_id');
     $client_secret = get_option('cc_client_secret');
-    ?>
-
-    <div class="container">
-
-        <div class="prerequisite-box">
-            <h2>🔧 Before You Start</h2>
-            <p>Follow these steps before connecting to Constant Contact:</p>
-            <ol>
-                <li>Go to the <a href="https://developer.constantcontact.com/" target="_blank" rel="noopener noreferrer">Constant Contact App Portal</a>.</li>
-                <li>Create a new application with a name of your choice.</li>
-                <li>Copy the <strong>API Key (Client ID)</strong> from the app details page.</li>
-                <li>Click <strong>Generate Client Secret</strong> and copy the code.</li>
-                <li>Set the <strong>Redirect URI</strong> to:<br><code>https://www.convertpro.net/oauth-connect2/</code></li>
-            </ol>
-            <p>Once you've completed these steps, enter your credentials below.</p>
-        </div>
-
-
-        <h2 class="cc-header" >Connect to Constant Contact</h2>
-
-        <form method="POST">
-            <div class="form-group">
-                <label for="client_id">Client ID</label>
-                <input type="text" name="client_id" id="client_id" required value="">
-            </div>
-            <div class="form-group">
-                <label for="client_secret">Client Secret</label>
-                <input type="text" name="client_secret" id="client_secret" required value="">
-            </div>
-
-            <button type="submit" name="connect" class="btn">Connect to Constant Contact</button>
-        </form>
-    </div>
-
-    <?php
+    $access_token = get_option('cc_access_token');
+    $refresh_token = get_option('cc_refresh_token');
+    $code = isset($_GET['code']) ? sanitize_text_field($_GET['code']) : null;
 
     if (isset($_POST['connect'])) {
         $client_id = sanitize_text_field($_POST['client_id']);
         $client_secret = sanitize_text_field($_POST['client_secret']);
         update_option('cc_client_id', $client_id);
         update_option('cc_client_secret', $client_secret);
-
-        //Generate state token and save in session
         $state = bin2hex(random_bytes(16));
+        $_SESSION['oauth_state'] = $state;
 
-        // Redirect to OAuth authorization URL
         $redirect_uri = home_url('/oauth-connect2/');
         $scope = rawurlencode("contact_data campaign_data offline_access");
-
         $auth_url = "https://authz.constantcontact.com/oauth2/default/v1/authorize?client_id={$client_id}&redirect_uri={$redirect_uri}&response_type=code&scope={$scope}&state={$state}";
-        
+
         wp_redirect($auth_url);
         exit;
     }
 
+    $show_token_section = false;
+    $error_message = '';
 
-    if (isset($_GET['code'])) {
-        $client_id = get_option('cc_client_id');
-        $client_secret = get_option('cc_client_secret');
-        $code = sanitize_text_field($_GET['code']);
-        $redirect_uri = home_url('/oauth-connect2/');
-
-        $access_token_data = getAccessToken($code, $client_id, $client_secret, $redirect_uri);
-
+    if ($code && empty($_SESSION['token_displayed'])) {
+        $access_token_data = getAccessToken($code, $client_id, $client_secret, home_url('/oauth-connect2/'));
         if ($access_token_data && isset($access_token_data['access_token'])) {
             update_option('cc_access_token', $access_token_data['access_token']);
             update_option('cc_refresh_token', $access_token_data['refresh_token']);
             update_option('cc_token_expiry', time() + $access_token_data['expires_in']);
-            ?>
-                <div class="notice success-msg">
-                    Successfully Connected!
-                </div>
-            <?php
+            $_SESSION['token_displayed'] = true;
+            $show_token_section = true;
         } else {
-            ?>
-                <div class="notice error-msg">
-                    The authorization code is invalid or has expired. Please enter valid credentials.
-                </div>
-            <?php
+            $error_message = 'The authorization code is invalid or has expired. Please enter valid credentials.';
         }
+    } elseif ($code && !empty($_SESSION['token_displayed'])) {
+        $error_message = 'The authorization code is invalid or has expired. Please enter valid credentials.';
+        $_SESSION['token_displayed'] = null;
     }
 
-    ?>
+    if (isset($_POST['revoke_access'])) {
+        revokeAuthorization();
+        $access_token = $refresh_token = null;
+        $_SESSION['token_displayed'] = null;
+    }
 
-    <!-- Revoke Access button -->
-    <form method="POST">
-        <button class="revoke_acces_btn" type="submit" name="revoke_access">Revoke Access</button>
-    </form>
-    <?php
-    $access_token = get_option('cc_access_token');
-    $refresh_token = get_option('cc_refresh_token');
-    // $token_expiry = get_option('cc_token_expiry');
-    
-    ?> 
-    
-    <!-- Access Token Display -->
-    <div class="container">
-        <div class="token-output">
-            <h3>Access Token</h3>
-            <pre class="token-box" id="access_token_box">
-                <?php 
-                    echo $access_token ?: "Not Found";
-                ?>
-            </pre>
-            <!-- <button id="copy-access" class="copy-btn" onclick="copyToken('access_token_box')">Copy</button> -->
+    if (isset($_POST['go_back'])) {
+        $_SESSION['token_displayed'] = null;
+        $show_token_section = false;
+    }
 
-            <h3>Refresh Token</h3>
-            <pre class="token-box" id="refresh_token_box">
-                <?php 
-                    echo $refresh_token ?: "Not Found";
-                ?>
-            </pre>
-            <!-- <button id="copy-refresh" class="copy-btn" onclick="copyToken('refresh_token_box')">Copy</button> -->
-        </div>
-    </div>
+    echo '<div class="cppro-cc-main-block"><div class="cppro-cc-container">';
 
-    <?php
+    if (!empty($error_message)) {
+        echo '<div class="cppro-cc-notice cppro-cc-error-msg">' . esc_html($error_message) . '</div>';
+    }
+
+    if ($show_token_section) {
+        echo '<form method="POST"><button class="cppro-cc-revoke_acces_btn" type="submit" name="go_back">Enter Client Credentials</button></form>';
+        echo '<div class="token-output">';
+        echo '<h3>Access Token</h3><pre class="ccpro-cc-token-box">' . esc_html($access_token ?: 'Not Found') . '</pre>';
+        echo '<h3>Refresh Token</h3><pre class="ccpro-cc-token-box">' . esc_html($refresh_token ?: 'Not Found') . '</pre>';
+        echo '</div>';
+        // echo '<form method="POST"><button class="cppro-cc-revoke_acces_btn" type="submit" name="revoke_access">Revoke Access</button></form>';
+    } else {
+        echo '<div class="cppro-cc-prerequisite-box">';
+        echo '<h2 class="cppro-cc-header">🔧 Before You Start</h2>';
+        echo '<p>Follow these steps before connecting to Constant Contact:</p>';
+        echo '<ol>';
+        echo '<li>Go to the <a href="https://developer.constantcontact.com/" target="_blank">Constant Contact App Portal</a>.</li>';
+        echo '<li>Create a new application and copy the Client ID and Secret.</li>';
+        echo '<li>Set the Redirect URI to: <code>' . home_url('/oauth-connect2/') . '</code></li>';
+        echo '</ol>';
+        echo '<p>Enter your credentials below.</p>';
+        echo '</div>';
+
+        echo '<h2 class="cc-header">Connect to Constant Contact</h2>';
+        echo '<form method="POST">';
+        echo '<div class="form-group"><label for="client_id">Client ID</label>';
+        echo '<input type="text" name="client_id" id="client_id" required></div>';
+        echo '<div class="form-group"><label for="client_secret">Client Secret</label>';
+        echo '<input type="text" name="client_secret" id="client_secret" required></div>';
+        echo '<button type="submit" name="connect" class="cppro-cc-connect-btn">Connect to Constant Contact</button>';
+        echo '</form>';
+    }
+    echo '</div></div>';
+
     return ob_get_clean();
 }
 
-/**
- * Function to Exchange Authorization Code for Access Token.
- *
- * @param string $code The authorization code received from the OAuth server.
- * @param string $client_id The client ID of the Constant Contact application.
- * @param string $client_secret The client secret of the Constant Contact application.
- * @param string $redirect_uri The redirect URI registered with the Constant Contact application.
- * @return array|null The access token data or null if the request fails.
- */
 function getAccessToken($code, $client_id, $client_secret, $redirect_uri) {
     $url = "https://authz.constantcontact.com/oauth2/default/v1/token";
-    $data = [
-        "code" => $code,
-        "redirect_uri" => $redirect_uri,
-        "grant_type" => "authorization_code"
-    ];
-    
+    $data = ["code" => $code, "redirect_uri" => $redirect_uri, "grant_type" => "authorization_code"];
     $auth = base64_encode("$client_id:$client_secret");
 
     $ch = curl_init($url);
@@ -207,26 +140,12 @@ function getAccessToken($code, $client_id, $client_secret, $redirect_uri) {
     return json_decode($response, true);
 }
 
-/**
- * Function to Refresh Access Token.
- *
- * @param string $client_id The client ID of the Constant Contact application.
- * @param string $client_secret The client secret of the Constant Contact application.
- * @return string The new access token or an error message if the refresh fails.
- */
 function refreshAccessToken($client_id, $client_secret) {
     $refresh_token = get_option('cc_refresh_token');
-
-    if (!$refresh_token) {
-        return "Error: No refresh token available.";
-    }
+    if (!$refresh_token) return "Error: No refresh token available.";
 
     $url = "https://authz.constantcontact.com/oauth2/default/v1/token";
-    $data = [
-        "refresh_token" => $refresh_token,
-        "grant_type" => "refresh_token"
-    ];
-
+    $data = ["refresh_token" => $refresh_token, "grant_type" => "refresh_token"];
     $auth = base64_encode("$client_id:$client_secret");
 
     $ch = curl_init($url);
@@ -243,33 +162,18 @@ function refreshAccessToken($client_id, $client_secret) {
     curl_close($ch);
 
     $tokens = json_decode($response, true);
-
     if (isset($tokens['access_token'])) {
         update_option('cc_access_token', $tokens['access_token']);
         update_option('cc_refresh_token', $tokens['refresh_token']);
         update_option('cc_token_expiry', time() + $tokens['expires_in']);
         return $tokens['access_token'];
-    } else {
-        return "Error: Failed to refresh token.";
     }
+
+    return "Error: Failed to refresh token.";
 }
 
-/**
- * Function to Revoke Authorization.
- *
- * This function deletes the stored access token, refresh token, 
- * and token expiry time from the WordPress options, effectively 
- * disconnecting the user from Constant Contact.
- */
 function revokeAuthorization() {
     delete_option('cc_access_token');
     delete_option('cc_refresh_token');
     delete_option('cc_token_expiry');
 }
-
-// Handle Form Submission for Revoking Access
-if (isset($_POST['revoke_access'])) {
-    revokeAuthorization();
-}
-
-?>


### PR DESCRIPTION
This pull request introduces a new plugin for handling OAuth connections with Constant Contact and includes a blank template for displaying the OAuth connection form. The most important changes include the creation of the plugin, adding a blank template, and handling the OAuth flow.

### Plugin creation and OAuth flow handling:

* [`constant-contact-oauth2.php`](diffhunk://#diff-9e267c54b5a984085f7f3049497647a2f6a8ab006b97da0e27c5c022f121ed5aR1-R275): Created a new plugin named "Constant Contact OAuth Connect" that registers a shortcode for handling OAuth connections, loads a blank template for the OAuth page, and includes functions for handling the OAuth connection process, refreshing access tokens, and revoking authorization.

### Template addition:

* [`blank-template.php`](diffhunk://#diff-047d0f573cc0f6f503ad9d5e26291ec8a74673b4129ffdcde3300d300ef1edd0R1-R179): Added a blank template to be used for the OAuth connection page, which includes basic HTML structure and CSS styles for the form and messages.